### PR TITLE
fix(docker): Corrigi .env para funcionamento da imagem Dockerfile

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
-USUARIO = root
-SENHA = senha123
-# HOST=host.docker.internal
-HOST = localhost
-PORTA_MYSQL = 3306
-BANCO_DE_DADOS = ZenStock
+USUARIO=root
+SENHA=senha123
+HOST=localhost
+PORTA_MYSQL=3306
+BANCO_DE_DADOS=ZenStock


### PR DESCRIPTION
Este PR traz apenas um commit focado em solucionar o problema de não funcionamento da imagem Docker que estávamos enfrentando. O erro estava nos espaços após o nome da variável no .env (Ex: "USUARIO" = "XYZ", deveria ser "USUARIO"="XYZ").

Modificado:
- Espaços entre o símbolo de igualdade, a variável e o valor da variável